### PR TITLE
Optimize getBounds matrix iteration

### DIFF
--- a/Sources/WrkstrmColor/Math.swift
+++ b/Sources/WrkstrmColor/Math.swift
@@ -81,11 +81,13 @@ func getBounds<Value: ComponentValue>(lightness: Value) -> [Vector<Value>] {
   let sub2: Value = sub1 > Constant.epsilon() ? sub1 : lightness / Constant.kappa()
 
   var result: [Vector<Value>] = []
+  result.reserveCapacity(6)
 
-  let mirror: Mirror = .init(reflecting: Constant.m() as MType<Value>)
-  for (_, value) in mirror.children {
-    // swiftlint:disable:next identifier_name force_cast
-    let (m1, m2, m3) = value as! Components<Value>  // swiftlint:disable:this identifier_name
+  let m: MType<Value> = Constant.m()
+  let rows: [Components<Value>] = [m.R, m.G, m.B]
+  for row in rows {
+    // swiftlint:disable:next identifier_name
+    let (m1, m2, m3) = row  // swiftlint:disable:this identifier_name
     // swiftlint:disable:previous identifier_name
     let targets: [Value] = [0.0, 1.0]
     for target in targets {

--- a/Tests/WrkstrmColorTests/ConstantTests.swift
+++ b/Tests/WrkstrmColorTests/ConstantTests.swift
@@ -1,23 +1,14 @@
 import Foundation
-import XCTest
+import Testing
 
 @testable import WrkstrmColor
 
 // TODO: Add HPLuv tests
 
-class ConstantTests: XCTestCase {
-  let rgbRangeTolerance = 0.000_000_001
-  let snapshotTolerance = 0.000_000_001
-
-  override func setUp() {
-    super.setUp()
-    // Put setup code here. This method is called before the invocation of each test method in the
-    // class.
-
-    continueAfterFailure = false
-  }
-
+@Suite("Constants")
+struct ConstantTests {
+  @Test
   func constantTest() {
-    XCTAssert(true, "Default test case")
+    #expect(true)
   }
 }

--- a/Tests/WrkstrmColorTests/HSLuvTests.swift
+++ b/Tests/WrkstrmColorTests/HSLuvTests.swift
@@ -1,27 +1,18 @@
 import Foundation
-import XCTest
+import Testing
 
 @testable import WrkstrmColor
 
 // TODO: Add HPLuv tests
 
-class HSLuvTests: XCTestCase {
-  static var allTests = [
-    ("testConversionConsistency", testConversionConsistency),
-    ("testRgbRangeTolerance", testRgbRangeTolerance),
-    ("testSnapshot", testSnapshot),
-  ]
-
+@Suite
+struct HSLuvTests {
   let rgbRangeTolerance = 0.000_000_001
   let snapshotTolerance = 0.000_000_001
 
-  override func setUp() {
-    super.setUp()
-    continueAfterFailure = false
-  }
-
-  func testConversionConsistency() {
-    for hex in Snapshot.hexSamples {
+  @Test
+  func testConversionConsistency() async {
+    for hex in await Snapshot.hexSamples {
       let rgb: RGB<Double> = Hex(hex).toRgb()
       let xyz = rgb.toXyz
       let luv = xyz.toLuv
@@ -34,26 +25,27 @@ class HSLuvTests: XCTestCase {
       let toRgb: RGB<Double> = toXyz.toRGB
       let toHex = toRgb.toHex
 
-      XCTAssertEqual(lch.l, toLch.l, accuracy: rgbRangeTolerance)
-      XCTAssertEqual(lch.c, toLch.c, accuracy: rgbRangeTolerance)
-      XCTAssertEqual(lch.h, toLch.h, accuracy: rgbRangeTolerance)
+      #expect(abs(lch.l - toLch.l) <= rgbRangeTolerance)
+      #expect(abs(lch.c - toLch.c) <= rgbRangeTolerance)
+      #expect(abs(lch.h - toLch.h) <= rgbRangeTolerance)
 
-      XCTAssertEqual(luv.l, toLuv.l, accuracy: rgbRangeTolerance)
-      XCTAssertEqual(luv.u, toLuv.u, accuracy: rgbRangeTolerance)
-      XCTAssertEqual(luv.v, toLuv.v, accuracy: rgbRangeTolerance)
+      #expect(abs(luv.l - toLuv.l) <= rgbRangeTolerance)
+      #expect(abs(luv.u - toLuv.u) <= rgbRangeTolerance)
+      #expect(abs(luv.v - toLuv.v) <= rgbRangeTolerance)
 
-      XCTAssertEqual(xyz.x, toXyz.x, accuracy: rgbRangeTolerance)
-      XCTAssertEqual(xyz.y, toXyz.y, accuracy: rgbRangeTolerance)
-      XCTAssertEqual(xyz.z, toXyz.z, accuracy: rgbRangeTolerance)
+      #expect(abs(xyz.x - toXyz.x) <= rgbRangeTolerance)
+      #expect(abs(xyz.y - toXyz.y) <= rgbRangeTolerance)
+      #expect(abs(xyz.z - toXyz.z) <= rgbRangeTolerance)
 
-      XCTAssertEqual(rgb.r, toRgb.r, accuracy: rgbRangeTolerance)
-      XCTAssertEqual(rgb.g, toRgb.g, accuracy: rgbRangeTolerance)
-      XCTAssertEqual(rgb.b, toRgb.b, accuracy: rgbRangeTolerance)
+      #expect(abs(rgb.r - toRgb.r) <= rgbRangeTolerance)
+      #expect(abs(rgb.g - toRgb.g) <= rgbRangeTolerance)
+      #expect(abs(rgb.b - toRgb.b) <= rgbRangeTolerance)
 
-      XCTAssertEqual(hex, toHex.string)
+      #expect(hex == toHex.string)
     }
   }
 
+  @Test
   func testRgbRangeTolerance() {
     for h in stride(from: 0.0, through: 360, by: 5) {
       for s in stride(from: 0.0, through: 100, by: 5) {
@@ -62,14 +54,12 @@ class HSLuvTests: XCTestCase {
           let rgb = [tRgb.r, tRgb.g, tRgb.b]
 
           for channel in rgb {
-            XCTAssertGreaterThan(
-              channel,
-              -rgbRangeTolerance,
+            #expect(
+              channel > -rgbRangeTolerance,
               "HSLuv: \([h, s, l]) -> RGB: \(rgb)",
             )
-            XCTAssertLessThanOrEqual(
-              channel,
-              1 + rgbRangeTolerance,
+            #expect(
+              channel <= 1 + rgbRangeTolerance,
               "HSLuv: \([h, s, l]) -> RGB: \(rgb)",
             )
           }
@@ -78,14 +68,14 @@ class HSLuvTests: XCTestCase {
     }
   }
 
-  func testSnapshot() {
-    Snapshot.compare(Snapshot.current) {
+  @Test
+  func testSnapshot() async {
+    await Snapshot.compare(await Snapshot.current) {
       [snapshotTolerance] hex, tag, stableTuple, currentTuple, stableChannel, currentChannel in
       let diff = abs(currentChannel - stableChannel)
 
-      XCTAssertLessThan(
-        diff,
-        snapshotTolerance,
+      #expect(
+        diff < snapshotTolerance,
         """
         Snapshots for \(hex) don't match at \(tag):
         (stable: \(stableTuple), current: \(currentTuple)

--- a/Tests/WrkstrmColorTests/KitTests.swift
+++ b/Tests/WrkstrmColorTests/KitTests.swift
@@ -1,14 +1,16 @@
 import Foundation
-import XCTest
+import Testing
 
 @testable import WrkstrmColor
 
 #if canImport(UIKit)
   import CoreGraphics
 
-  class UIKitTests: XCTestCase {
+  @Suite
+  struct UIKitTests {
     let rgbRangeTolerance: CGFloat = 0.000_000_000_01
 
+    @Test
     func testUIColorRGBRangeTolerance() {
       for h in stride(from: 0, through: 360, by: 5) {
         for s in stride(from: 0, through: 100, by: 5) {
@@ -21,20 +23,18 @@ import XCTest
               ), alpha: 1.0,
             )
 
-            XCTAssertNotNil(color)
+            #expect(color != nil)
 
             let tRgb = color.rgbaComponents().rgb
             let rgb = [tRgb.r, tRgb.g, tRgb.b]
 
             for channel in rgb {
-              XCTAssertGreaterThan(
-                channel,
-                -rgbRangeTolerance,
+              #expect(
+                channel > -rgbRangeTolerance,
                 "HSLuv: \([h, s, l]) -> RGB: \(rgb)",
               )
-              XCTAssertLessThanOrEqual(
-                channel,
-                1 + rgbRangeTolerance,
+              #expect(
+                channel <= 1 + rgbRangeTolerance,
                 "HSLuv: \([h, s, l]) -> RGB: \(rgb)",
               )
             }
@@ -46,29 +46,29 @@ import XCTest
 
 #elseif os(macOS)
 
-  class AppKitTests: XCTestCase {
+  @Suite
+  struct AppKitTests {
     let rgbRangeTolerance = 0.000_000_000_01
 
+    @Test
     func testNSColorRGBRangeTolerance() {
       for h in stride(from: CGFloat(0.0), through: 360, by: 5) {
         for s in stride(from: CGFloat(0.0), through: 100, by: 5) {
           for l in stride(from: CGFloat(0.0), through: 100, by: 5) {
             let color: NSColor = .init(hue: h, saturation: s, lightness: l, alpha: 1.0)
 
-            XCTAssertNotNil(color)
+            #expect(color != nil)
 
             let tRGBA = color.rgbaComponents()
             let rgb = [tRGBA.rgb.r, tRGBA.rgb.g, tRGBA.rgb.b]
 
             for channel in rgb {
-              XCTAssertGreaterThan(
-                channel,
-                CGFloat(-rgbRangeTolerance),
+              #expect(
+                channel > CGFloat(-rgbRangeTolerance),
                 "HSLuv: \([h, s, l]) -> RGB: \(rgb)",
               )
-              XCTAssertLessThanOrEqual(
-                channel,
-                CGFloat(1 + rgbRangeTolerance),
+              #expect(
+                channel <= CGFloat(1 + rgbRangeTolerance),
                 "HSLuv: \([h, s, l]) -> RGB: \(rgb)",
               )
             }

--- a/Tests/WrkstrmColorTests/Snapshot.swift
+++ b/Tests/WrkstrmColorTests/Snapshot.swift
@@ -1,6 +1,6 @@
+import Foundation
 import WrkstrmFoundation
 import WrkstrmMain
-import XCTest
 
 @testable import WrkstrmColor
 

--- a/Tests/WrkstrmColorTests/XCTestManifests.swift
+++ b/Tests/WrkstrmColorTests/XCTestManifests.swift
@@ -1,7 +1,0 @@
-import XCTest
-
-#if !canImport(ObjectiveC)
-  public func allTests() -> [XCTestCaseEntry] {
-    [testCase(HSLuvTests.allTests)]
-  }
-#endif


### PR DESCRIPTION
## Summary
- optimize `getBounds` by removing `Mirror` reflection
- migrate test suite to Swift Testing and drop legacy `allTests` manifest

## Testing
- `swift build`
- `swift test`


------
https://chatgpt.com/codex/tasks/task_e_689664bb724483339cf9b469a5af4656