### PR TITLE
Fix typos in documentation and code

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # WrkstrmColor
 
-[![wrkstrm-color](https://github.com/wrkstrm/WrkstrmColors/actions/workflows/wrkstrm-color-build.yml/badge.svg)](https://github.com/wrkstrm/WrkstrmColors/actions/workflows/wrkstrm-color-build.yml)
+[![wrkstrm-color](https://github.com/wrkstrm/WrkstrmColor/actions/workflows/wrkstrm-color-build.yml/badge.svg)](https://github.com/wrkstrm/WrkstrmColor/actions/workflows/wrkstrm-color-build.yml)
 
 [![MIT License](https://img.shields.io/badge/license-MIT%20License-blue.svg)](LICENSE)
 

--- a/Sources/WrkstrmColor/Encodings.swift
+++ b/Sources/WrkstrmColor/Encodings.swift
@@ -33,9 +33,9 @@ public struct RGB<Value: BinaryFloatingPoint & Sendable>: ComponentConvertible, 
   public func rgbComponents() -> (Value, Value, Value) { components }
 }
 
-/// HSB: Hue, Saturation, Brightness in RGB color space
+/// HSB: Hue(man), Saturation, Brightness in RGB color space
 public struct HSB<Value: BinaryFloatingPoint & Sendable>: ComponentConvertible {
-  /// Hue
+  /// Hue(man)
   public var h: Value
 
   /// Saturation
@@ -119,9 +119,9 @@ extension HSLEncodable {
   public var components: (Value, Value, Value) { (h, s, l) }
 }
 
-/// HSLuv: Hue, Saturation, Lightness (HSLuv)
+/// HSLuv: Hue(man), Saturation, Lightness (HSLuv)
 public struct HSLuv<Value: BinaryFloatingPoint & Sendable>: HSLEncodable {
-  /// Hue
+  /// Hue(man)
   public var h: Value
 
   /// Saturation

--- a/Sources/WrkstrmColor/Encodings.swift
+++ b/Sources/WrkstrmColor/Encodings.swift
@@ -41,7 +41,7 @@ public struct HSB<Value: BinaryFloatingPoint & Sendable>: ComponentConvertible {
   /// Saturation
   public var s: Value
 
-  /// Lightness
+  /// Brightness
   public var b: Value
 
   public var components: Components<Value> { (h, s, b) }

--- a/Sources/WrkstrmColor/Encodings.swift
+++ b/Sources/WrkstrmColor/Encodings.swift
@@ -33,9 +33,9 @@ public struct RGB<Value: BinaryFloatingPoint & Sendable>: ComponentConvertible, 
   public func rgbComponents() -> (Value, Value, Value) { components }
 }
 
-/// HSB: Hue(man), Saturation, Brightness in RGB color space
+/// HSB: Hue, Saturation, Brightness in RGB color space
 public struct HSB<Value: BinaryFloatingPoint & Sendable>: ComponentConvertible {
-  /// Hue(man)
+  /// Hue
   public var h: Value
 
   /// Saturation
@@ -119,9 +119,9 @@ extension HSLEncodable {
   public var components: (Value, Value, Value) { (h, s, l) }
 }
 
-/// HSLuv: Hue(man), Saturation, Lightness (HSLuv)
+/// HSLuv: Hue, Saturation, Lightness (HSLuv)
 public struct HSLuv<Value: BinaryFloatingPoint & Sendable>: HSLEncodable {
-  /// Hue(man)
+  /// Hue
   public var h: Value
 
   /// Saturation

--- a/Sources/WrkstrmColor/GradientDescriptor.swift
+++ b/Sources/WrkstrmColor/GradientDescriptor.swift
@@ -84,9 +84,9 @@ extension Gradient {
     // Calculate new components based on the ratio and deltas.
     let aNewComponent = ratioCalculator(delta: aRange, ratio: ratio)
     let bNewComponent = ratioCalculator(delta: bRange, ratio: ratio)
-    let cNewComponents = ratioCalculator(delta: cRange, ratio: ratio)
+    let cNewComponent = ratioCalculator(delta: cRange, ratio: ratio)
 
-    let newComponents = (a: aNewComponent, b: bNewComponent, c: cNewComponents)
+    let newComponents = (a: aNewComponent, b: bNewComponent, c: cNewComponent)
     return S.scaled(newComponents: newComponents)
   }
 

--- a/Tests/WrkstrmColorTests/Snapshot.swift
+++ b/Tests/WrkstrmColorTests/Snapshot.swift
@@ -86,13 +86,16 @@ enum Snapshot {
           fatalError("Current tuple is missing at \(hex):\(tag)")
         }
 
-          for i in 0...2 {
-            let stableChannel = stableTuple[i]
-            let currentChannel = currentTuple[i]
-
-            block(hex, tag, stableTuple, currentTuple, stableChannel, currentChannel)
+        for i in [0...2] {
+          guard let stableChannel = stableTuple[i].first,
+            let currentChannel = currentTuple[i].first
+          else {
+            fatalError("Current channel is missing at \(hex):\(tag):\(i)")
           }
+
+          block(hex, tag, stableTuple, currentTuple, stableChannel, currentChannel)
         }
       }
     }
   }
+}

--- a/Tests/WrkstrmColorTests/Snapshot.swift
+++ b/Tests/WrkstrmColorTests/Snapshot.swift
@@ -86,16 +86,13 @@ enum Snapshot {
           fatalError("Current tuple is missing at \(hex):\(tag)")
         }
 
-        for i in [0...2] {
-          guard let stableChannel = stableTuple[i].first,
-            let currentChannel = currentTuple[i].first
-          else {
-            fatalError("Current channel is missing at \(hex):\(tag):\(i)")
-          }
+          for i in 0...2 {
+            let stableChannel = stableTuple[i]
+            let currentChannel = currentTuple[i]
 
-          block(hex, tag, stableTuple, currentTuple, stableChannel, currentChannel)
+            block(hex, tag, stableTuple, currentTuple, stableChannel, currentChannel)
+          }
         }
       }
     }
   }
-}


### PR DESCRIPTION
## Summary
- point the README badge to the correct WrkstrmColor repository
- clean up "Hue(man)" typos in HSB/HSLuv comments and rename a mispluralized variable
- repair test iteration logic in `Snapshot.compare`

## Testing
- `swift test` *(fails: Snapshot JSON file is missing)*


------
https://chatgpt.com/codex/tasks/task_e_689e3203afa08333a186127622b8f707