### PR TITLE
Use test bundle to load snapshot JSON

### DIFF
--- a/Tests/WrkstrmColorTests/Snapshot.swift
+++ b/Tests/WrkstrmColorTests/Snapshot.swift
@@ -26,10 +26,11 @@ enum Snapshot {
 
   static var stable: SnapshotDictionary = {
     guard
-      let jsonData = JSON.Resource.load(fileName: "snapshot-rev4"),
+      let url = Bundle.module.url(forResource: "snapshot-rev4", withExtension: "json"),
+      let jsonData = try? Data(contentsOf: url),
       let jsonResult = try? JSONSerialization.jsonObject(
         with: jsonData,
-        options: .fragmentsAllowed,
+        options: .fragmentsAllowed
       ) as? SnapshotDictionary
     else {
       fatalError("Snapshot JSON file is missing")


### PR DESCRIPTION
## Summary
- load snapshot JSON using `Bundle.module` to ensure file is found at runtime

## Testing
- `swift test`


------
https://chatgpt.com/codex/tasks/task_e_689e369296b88333a22af8cc6369b7d3